### PR TITLE
updated test.py handle json.loads error for python>=3.9

### DIFF
--- a/p7/test.py
+++ b/p7/test.py
@@ -757,8 +757,8 @@ def rerun_notebook(orig_notebook):
     subprocess.check_output(cmd, shell=True)
 
     # parse notebook
-    with open(new_notebook) as f:
-        nb = json.load(f, encoding='utf-8')
+    with open(new_notebook, encoding='utf-8') as f:
+        nb = json.load(f)
     return nb
 
 


### PR DESCRIPTION
It will work for both python==3.8.5 and python>=3.9.

Those who have already solved p7, they will NOT have to change anything. This modification is just to help students who are not using python 3.8.5 (RECOMMENDED for this course), but are using python 3.9.